### PR TITLE
ENH: add argument help documentation.

### DIFF
--- a/click_example/cli.py
+++ b/click_example/cli.py
@@ -17,7 +17,7 @@ import click
 @click.option('-v', '--verbose', is_flag=True, multiple=True)
 def count(number: int, quiet, verbose):
     """
-    Display progressbar while counting to a user provided number.
+    Display progressbar while counting to the user provided integer NUMBER.
     """
     click.clear()
     logging_level = logging.INFO + 10 * len(quiet) - 10 * len(verbose)


### PR DESCRIPTION
Click does not allow the `help` parameter for arguments to follow the
syntax of Linux.

To document argument `help` strings place them in the main help
statement of the docstring.  NOTE: The argument name will be all caps.